### PR TITLE
Fix for https://github.com/wycats/rack-offline/issues#issue/5.

### DIFF
--- a/lib/rack/offline.rb
+++ b/lib/rack/offline.rb
@@ -57,7 +57,7 @@ module Rack
 
       @logger.debug body.join("\n")
 
-      [200, {"Content-Type" => "text/cache-manifest"}, body.join("\n")]
+      [200, {"Content-Type" => "text/cache-manifest"}, body.inject([]){|a, item| a << item << "\n"} ] 
     end
 
   private


### PR DESCRIPTION
 Also, rack response expects an array (http://rack.rubyforge.org/doc/classes/Rack/Response.html).
