### PR TITLE
Getting uncached mode to work

### DIFF
--- a/lib/rack-offline.rb
+++ b/lib/rack-offline.rb
@@ -7,7 +7,7 @@ module Rails
       @app.call(env)
     end
 
-    def initialize(app = Rails.application, &block)
+    def initialize(options = {}, app = Rails.application, &block)
       config = app.config
       root = config.paths.public.to_a.first
 
@@ -17,7 +17,7 @@ module Rails
         :cache => config.cache_classes,
         :root => root,
         :logger => Rails.logger
-      }
+      }.merge(options)
 
       super opts, &block
     end

--- a/lib/rack/offline.rb
+++ b/lib/rack/offline.rb
@@ -73,7 +73,8 @@ module Rack
 
     def precache_key!
       hash = @config.cache.map do |item|
-        Digest::SHA2.hexdigest(@root.join(item).read)
+        path = @root.join(item)
+        Digest::SHA2.hexdigest(path.read) if File.file?(path)
       end
 
       @key = Digest::SHA2.hexdigest(hash.join)

--- a/lib/rack/offline.rb
+++ b/lib/rack/offline.rb
@@ -74,7 +74,7 @@ module Rack
     def precache_key!
       hash = @config.cache.map do |item|
         path = @root.join(item)
-        Digest::SHA2.hexdigest(path.read) if File.file?(path)
+        Digest::SHA2.hexdigest(path.read) if ::File.file?(path)
       end
 
       @key = Digest::SHA2.hexdigest(hash.join)

--- a/lib/rack/offline.rb
+++ b/lib/rack/offline.rb
@@ -66,7 +66,7 @@ module Rack
 
       @logger.debug body.join("\n")
 
-      [200, {"Content-Type" => "text/cache-manifest"}, body.join("\n")]
+      [200, {"Content-Type" => "text/cache-manifest"}, [body.join("\n")]]
     end
 
   private

--- a/spec/base_offline_spec.rb
+++ b/spec/base_offline_spec.rb
@@ -9,17 +9,33 @@ describe "Generating a basic manifest" do
 
   it_should_behave_like "a cache manifest"
 
-  it "returns a different cache-busting comment each time" do
-    cache_buster = body[/^# .{64}$/]
-    get "/"
-    body[/^# .{64}$/].should_not == cache_buster
-  end
-
   it "doesn't contain a network section" do
     body.should_not =~ %r{^NETWORK:}
   end
 
   it "doesn't contain a fallback section" do
     body.should_not =~ %r{^FALLBACK:}
+  end
+  
+  describe "cache-busting comment" do
+    context "if no interval is specified" do
+      self.app = Rack::Offline.configure do
+        cache "images/masthead.png"
+      end
+
+      it_should_behave_like "uncached cache manifests"
+    end
+
+    context "if an interval is specified" do
+      INTERVAL = 15
+      self.app = Rack::Offline.configure(:cache_interval => INTERVAL) do
+        cache "images/masthead.png"
+      end
+      
+      before do
+        @interval = INTERVAL
+      end
+      it_should_behave_like "uncached cache manifests"
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,3 +52,26 @@ shared_examples_for "a cache manifest" do
     body.should =~ %r{^# .{64}$}
   end
 end
+
+shared_examples_for "uncached cache manifests" do
+  before do
+    @interval ||= Rack::Offline::UNCACHED_KEY_INTERVAL
+    Time.stub(:now).and_return(Time.at(@interval))
+    get "/"
+  end
+  
+  it "returns the same cache-busting comment within a given interval" do
+    cache_buster = body[/^# .{64}$/]
+    Time.stub(:now).and_return(Time.at(2 * @interval - 1))
+    get "/"
+    body[/^# .{64}$/].should == cache_buster
+  end    
+
+  it "returns a different cache-busting comment after the interval" do
+    Time.stub(:now).and_return(Time.at(@interval))
+    cache_buster = body[/^# .{64}$/]
+    Time.stub(:now).and_return(Time.at(2 * @interval))
+    get "/"
+    body[/^# .{64}$/].should_not == cache_buster
+  end
+end


### PR DESCRIPTION
Right now, Rack::Offline offers an uncached mode in which the manifest is constantly regenerated; it's a great idea for development (and is on by default in dev environment), but doesn't actually work.  The problem is that the cache-breaking comment in the manifest is generated by the following line:

``` ruby
Digest::SHA2.hexdigest(Time.now.to_s + Time.now.usec.to_s)
```

Since the browser downloads the cache twice (once at the beginning, and once at the end for verification), the use of usec means the manifest will always be different and the app cache can never be built.

I've written a patch (with tests) to change this behavior; with these changes, the comment will only change after a configurable interval (by default 10 seconds) to allow the browser to download the cache first.  (There's always a risk that the download will start too close to the boundary, but since this is development only, the developer can adjust the interval to his or her preference.)

PS thanks for the very useful gem!  I remember hearing about it in a side talk at the jQuery conference last year in Mountain View, and am very excited to finally be using it.
