### PR TITLE
Sort cached files before generating manifest key

### DIFF
--- a/lib/rack/offline.rb
+++ b/lib/rack/offline.rb
@@ -72,7 +72,7 @@ module Rack
   private
 
     def precache_key!
-      hash = @config.cache.map do |item|
+      hash = @config.cache.sort!.map do |item|
         path = @root.join(item)
         Digest::SHA2.hexdigest(path.read) if ::File.file?(path)
       end


### PR DESCRIPTION
My heroku app seems to be slurping up the file list in a different order on each dyno, producing a different manifest key for each process that's running my application.  Sorting the files before generating the key fixes the problem.
