### PR TITLE
Add font file types to the cache manifest

### DIFF
--- a/lib/rack-offline.rb
+++ b/lib/rack-offline.rb
@@ -28,7 +28,7 @@ module Rails
         if Rails.version >= "3.1" && Rails.configuration.assets.enabled
           files = Dir[
             "#{root}/**/*.html",
-            "#{root}/assets/**/*.{js,css,jpg,png,gif}"]
+            "#{root}/assets/**/*.{js,css,jpg,png,gif,woff,eot,ttf}"]
         else
           files = Dir[
             "#{root}/**/*.html",


### PR DESCRIPTION
This adds .woff, .eot and .ttf files from the assets directory into the cache manifest.
