### PR TITLE
Respect the order of cache entries

### DIFF
--- a/lib/rack/offline.rb
+++ b/lib/rack/offline.rb
@@ -43,24 +43,25 @@ module Rack
 
     def call(env)
       key = @key || uncached_key
+      uri_parser = URI.const_defined?(:DEFAULT_PARSER) ? URI::DEFAULT_PARSER : URI
 
       body = ["CACHE MANIFEST"]
       body << "# #{key}"
       @config.cache.each do |item|
-        body << URI.escape(item.to_s)
+        body << uri_parser.escape(item.to_s)
       end
 
       unless @config.network.empty?
         body << "" << "NETWORK:"
         @config.network.each do |item|
-          body << URI.escape(item.to_s)
+          body << uri_parser.escape(item.to_s)
         end
       end
 
       unless @config.fallback.empty?
         body << "" << "FALLBACK:"
         @config.fallback.each do |namespace, url|
-          body << "#{namespace} #{URI.escape(url.to_s)}"
+          body << "#{namespace} #{uri_parser.escape(url.to_s)}"
         end
       end
 

--- a/lib/rack/offline.rb
+++ b/lib/rack/offline.rb
@@ -72,7 +72,7 @@ module Rack
   private
 
     def precache_key!
-      hash = @config.cache.sort!.map do |item|
+      hash = @config.cache.sort.map do |item|
         path = @root.join(item)
         Digest::SHA2.hexdigest(path.read) if ::File.file?(path)
       end

--- a/spec/cached_offline_spec.rb
+++ b/spec/cached_offline_spec.rb
@@ -99,4 +99,12 @@ describe "Generating a manifest in cached mode" do
     end
   end
 
+  it "respects the order of cache entries" do
+    self.class.app = self.class.new_app
+    with_session :new_app_with_sorted_cache_entries do
+      get "/"
+      entries = ["hello.html", "hello.css", "javascripts/hello.js"].join("\n")
+      body.should include(entries)
+    end
+  end
 end


### PR DESCRIPTION
In our application, we're depending on the order of the cache entries (to include the javascripts dynamically in the DOM in proper order). This PR keeps the cache key computation independent of sorting order, while not mutating the `@config.cache` array.
