### PR TITLE
cache asset pipeline files in development mode

### DIFF
--- a/lib/rack-offline.rb
+++ b/lib/rack-offline.rb
@@ -34,6 +34,7 @@ module Rails
             files = Rails.application.assets.each_logical_path(Rails.configuration.assets.precompile).map do |fn|
               "#{root}/#{Rails.configuration.assets.prefix}/#{fn}"
             end
+            files += Dir["#{root}/**/*.html"]
           end
         else
           files = Dir[

--- a/lib/rack-offline.rb
+++ b/lib/rack-offline.rb
@@ -25,10 +25,16 @@ module Rails
 
     def cache_block(root)
       Proc.new do
-        if Rails.version >= "3.1" && Rails.configuration.assets.enabled
-          files = Dir[
-            "#{root}/**/*.html",
-            "#{root}/assets/**/*.{js,css,jpg,png,gif}"]
+        if Rails.version >= "3.1"
+          if Rails.configuration.assets.enabled
+            files = Dir[
+              "#{root}/**/*.html",
+              "#{root}/#{Rails.configuration.assets.prefix}/**/*.{js,css,jpg,png,gif}"]
+          else
+            files = Rails.application.assets.each_logical_path(Rails.configuration.assets.precompile).map do |fn|
+              "#{root}/#{Rails.configuration.assets.prefix}/#{fn}"
+            end
+          end
         else
           files = Dir[
             "#{root}/**/*.html",
@@ -36,7 +42,7 @@ module Rails
             "#{root}/javascripts/**/*.js",
             "#{root}/images/**/*.*"]
         end
-        
+
         files.each do |file|
           cache Pathname.new(file).relative_path_from(root)
         end


### PR DESCRIPTION
Previously, unless `configuration.assets.enabled`, which is false in development by default, rack-offline would fall back by to the Rails 2.x public/{javascripts,stylesheets} files. This behavior made the default configuration useless unless the developer continuously runs `rake assets:precompile` after each asset change.

The new behavior causes it to cache every file that _would be present_ in public/assets/ after running a `rake assets:precompile`. The logic is from:

https://github.com/sstephenson/sprockets/blob/master/lib/sprockets/manifest.rb#L115-L116

Additionally, it now checks the configured assets directory prefix, instead of using the hard-coded "assets".
