### PR TITLE
assets.enabled is always nil in production

### DIFF
--- a/lib/rack-offline.rb
+++ b/lib/rack-offline.rb
@@ -29,7 +29,7 @@ module Rails
            (Rails.version >= "4.0" && !Rails.configuration.assets.compile)
           files = Dir[
             "#{root}/**/*.html",
-            "#{root}/assets/**/*.{js,css,jpg,png,gif}"]
+            "#{root}/assets/**/*.{js,css,jpg,png,gif,svg}"]
         else
           files = Dir[
             "#{root}/**/*.html",

--- a/lib/rack-offline.rb
+++ b/lib/rack-offline.rb
@@ -25,16 +25,17 @@ module Rails
 
     def cache_block(root)
       Proc.new do
-        if Rails.version >= "3.1" && Rails.configuration.assets.enabled
+        if (Rails.version >= "3.1" && Rails.configuration.assets.enabled) ||
+           (Rails.version >= "4.0" && !Rails.configuration.assets.compile)
           files = Dir[
-            "#{root}/{**/,}*.html",
-            "#{root}/assets/{**/,}*.{js,css,jpg,png,gif}"]
+            "#{root}/**/*.html",
+            "#{root}/assets/**/*.{js,css,jpg,png,gif}"]
         else
           files = Dir[
-            "#{root}/{**/,}*.html",
-            "#{root}/stylesheets/{**/,}*.css",
-            "#{root}/javascripts/{**/,}*.js",
-            "#{root}/images/{**/,}*.*"]
+            "#{root}/**/*.html",
+            "#{root}/stylesheets/**/*.css",
+            "#{root}/javascripts/**/*.js",
+            "#{root}/images/**/*.*"]
         end
         
         files.each do |file|

--- a/lib/rack-offline.rb
+++ b/lib/rack-offline.rb
@@ -27,14 +27,14 @@ module Rails
       Proc.new do
         if Rails.version >= "3.1" && Rails.configuration.assets.enabled
           files = Dir[
-            "#{root}/**/*.html",
-            "#{root}/assets/**/*.{js,css,jpg,png,gif}"]
+            "#{root}/{**/,}*.html",
+            "#{root}/assets/{**/,}*.{js,css,jpg,png,gif}"]
         else
           files = Dir[
-            "#{root}/**/*.html",
-            "#{root}/stylesheets/**/*.css",
-            "#{root}/javascripts/**/*.js",
-            "#{root}/images/**/*.*"]
+            "#{root}/{**/,}*.html",
+            "#{root}/stylesheets/{**/,}*.css",
+            "#{root}/javascripts/{**/,}*.js",
+            "#{root}/images/{**/,}*.*"]
         end
         
         files.each do |file|


### PR DESCRIPTION
The manifest does not correctly list files in production mode because assets.enabled is always nil in Rails 4.
