### PR TITLE
avoid caching old assets preserved by sprockets

### DIFF
--- a/lib/rack-offline.rb
+++ b/lib/rack-offline.rb
@@ -41,7 +41,7 @@ module Rails
           path.gsub(/^(.+)-[0-9a-f]{7,40}\.([^.]+)$/, '\1.\2')
         end
 
-        most_recent_files = files.sort_by { |f| File.ctime(f) }.reverse.reduce([]) do |list, file|
+        most_recent_files = files.sort_by { |f| File.mtime(f) }.reverse.reduce([]) do |list, file|
           list << file unless list.map(&strip_fingerprint).include?(strip_fingerprint.call(file))
           list
         end

--- a/lib/rack-offline.rb
+++ b/lib/rack-offline.rb
@@ -50,7 +50,7 @@ module Rails
         end
 
         files.each do |file|
-          cache Pathname.new(file).relative_path_from(root)
+          cache ActionController::Base.helpers.asset_path(Pathname.new(file).relative_path_from(root))
         end
 
         network "*"

--- a/lib/rack-offline.rb
+++ b/lib/rack-offline.rb
@@ -36,8 +36,17 @@ module Rails
             "#{root}/javascripts/**/*.js",
             "#{root}/images/**/*.*"]
         end
-        
-        files.each do |file|
+
+        strip_fingerprint = lambda do |path|
+          path.gsub(/^(.+)-[0-9a-f]{7,40}\.([^.]+)$/, '\1.\2')
+        end
+
+        most_recent_files = files.sort_by { |f| File.ctime(f) }.reverse.reduce([]) do |list, file|
+          list << file unless list.map(&strip_fingerprint).include?(strip_fingerprint.call(file))
+          list
+        end
+
+        most_recent_files.each do |file|
           cache Pathname.new(file).relative_path_from(root)
         end
 


### PR DESCRIPTION
Because sprockets by default leaves around the 2 previous copies of any assets, the default behavior of rack-offline.rb for rails is to cache three times the necessary data.  This code picks only the latest file (based on ctime) and adds that to the manifest.  Wasn't sure if this warranted testing since there is no corresponding test for rack-offline.
