### PR TITLE
Add "no cache" headers to manifest response

### DIFF
--- a/lib/rack/offline.rb
+++ b/lib/rack/offline.rb
@@ -65,8 +65,15 @@ module Rack
       end
 
       @logger.debug body.join("\n")
+      
+      headers = {
+        "Content-Type" => "text/cache-manifest",
+        "Expires" => DateTime.current,
+        "Cache-Control" => "max-age=0, no-cache, no-store, must-revalidate",
+        "Pragma" => "no-cache"
+      }
 
-      [200, {"Content-Type" => "text/cache-manifest"}, [body.join("\n")]]
+      [200, headers, [body.join("\n")]]
     end
 
   private


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Using_the_application_cache:

> It's a good idea to set expires headers on your web server for *.appcache files to expire immediately. This avoids the risk of caching manifest files. 

This PR adds Expires, Cache-Control, & Pragma headers to prevent browsers (specifically Firefox) from caching the manifest file.

It's possible this is not always desired behavior, so this should perhaps be optional.  Opening PR to start discussion.
