### PR TITLE
gemspec: link to the repo

### DIFF
--- a/rack-offline.gemspec
+++ b/rack-offline.gemspec
@@ -17,6 +17,9 @@ Gem::Specification.new do |s|
   s.email             = 'wycats@gmail.com'
   s.homepage          = 'http://www.yehudakatz.com'
   s.rubyforge_project = 'rack-offline'
+  s.metadata = {
+    'source_code_uri' => 'https://github.com/wycats/rack-offline'
+  }
 
   s.files        = Dir['CHANGELOG', 'README', 'LICENSE', 'lib/**/*']
   s.require_path = 'lib'


### PR DESCRIPTION
https://rubygems.org/gems/rack-offline should include a link to some page with fundamental usage instructions. Link to the repo seems to serve this purpose well.